### PR TITLE
Repo Auth / Middleware

### DIFF
--- a/scot4/templates/api/scot4-api-db-management-jobs.yaml
+++ b/scot4/templates/api/scot4-api-db-management-jobs.yaml
@@ -39,6 +39,9 @@ spec:
         - secretRef:
             name: scot4-env-secrets
       {{- end }}
+      {{- if .Values.scot4.common.imagePullSecret }}
       imagePullSecrets:
-      - name: scot4-image-pull-secret 
+      - name: {{ .Values.scot4.common.imagePullSecret }}
+      {{- end }}
+
 {{- end }}

--- a/scot4/templates/api/scot4-api-deployment.yaml
+++ b/scot4/templates/api/scot4-api-deployment.yaml
@@ -78,7 +78,7 @@ spec:
             name: scot4-env-secrets
         command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.scot4.api.containerPort }}"]
         volumeMounts:
-        - name: scot4-api-files-storage 
+        - name: scot4-api-files-storage
           mountPath: /var/scot_files
           readOnly: false
         ports:
@@ -102,12 +102,14 @@ spec:
           limits:
             memory: "8192Mi"
       volumes:
-      - name: scot4-api-files-storage 
+      - name: scot4-api-files-storage
         persistentVolumeClaim:
           claimName: scot4-api-pv-claim
       securityContext:
         runAsUser: 3000
         runAsGroup: 3000
         fsGroup: 3000
+      {{- if .Values.scot4.common.imagePullSecret }}
       imagePullSecrets:
-      - name: scot4-image-pull-secret 
+      - name: {{ .Values.scot4.common.imagePullSecret }}
+      {{- end }}

--- a/scot4/templates/flair/scot4-flair-deployment.yaml
+++ b/scot4/templates/flair/scot4-flair-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - configMapRef:
             name: scot4-flair-env-config
         volumeMounts:
-        - name: scot4-flair-opt-storage 
+        - name: scot4-flair-opt-storage
           mountPath: /opt/flair/var
       {{- end }}
       containers:
@@ -53,7 +53,7 @@ spec:
         - containerPort: {{ .Values.scot4.flair.containerPort }}
           name: scot4-flair
         volumeMounts:
-        - name: scot4-flair-opt-storage 
+        - name: scot4-flair-opt-storage
           mountPath: /opt/flair/var
           readOnly: false
       - image: "{{ .Values.scot4.flair.repository }}:{{ .Values.scot4.flair.tag }}"
@@ -66,13 +66,15 @@ spec:
             name: scot4-flair-env-config
         command: ["/opt/flair/script/Flair", "minion", "worker", "-m", "production", "-j", "{{ .Values.scot4.flair.numMinionWorkers }}"]
         volumeMounts:
-        - name: scot4-flair-opt-storage 
+        - name: scot4-flair-opt-storage
           mountPath: /opt/flair/var
           readOnly: false
+      {{- if .Values.scot4.common.imagePullSecret }}
       imagePullSecrets:
-      - name: scot4-image-pull-secret 
+      - name: {{ .Values.scot4.common.imagePullSecret }}
+      {{- end }}
       volumes:
-      - name: scot4-flair-opt-storage 
+      - name: scot4-flair-opt-storage
         persistentVolumeClaim:
           claimName: scot4-flair-opt-pv-claim
       securityContext:

--- a/scot4/templates/frontend/scot4-frontend-deployment.yaml
+++ b/scot4/templates/frontend/scot4-frontend-deployment.yaml
@@ -39,5 +39,7 @@ spec:
         ports:
         - containerPort: 8080
           name: scot4-frontend
+      {{- if .Values.scot4.common.imagePullSecret }}
       imagePullSecrets:
-      - name: scot4-image-pull-secret 
+      - name: {{ .Values.scot4.common.imagePullSecret }}
+      {{- end }}

--- a/scot4/templates/frontend/scot4-frontend-ingress.yaml
+++ b/scot4/templates/frontend/scot4-frontend-ingress.yaml
@@ -3,7 +3,9 @@ kind: Ingress
 metadata:
   name: scot4-tls-ingress
   annotations:
+    {{- if eq .Values.scot4.frontend.enableTraefikMiddleware "true" }}
     traefik.ingress.kubernetes.io/router.middlewares: scot4-strip-flair-prefix@kubernetescrd, scot4-http-redirect@kubernetescrd
+    {{- end }}
 spec:
   tls:
   - hosts:
@@ -35,7 +37,8 @@ spec:
             port:
               number: {{ .Values.scot4.flair.containerPort }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+{{- if eq .Values.scot4.frontend.enableTraefikMiddleware "true" }}
+apiVersion: {{ .Values.scot4.frontend.traefikMiddlewareVersion }}
 kind: Middleware
 metadata:
   name: strip-flair-prefix
@@ -45,7 +48,7 @@ spec:
     prefixes:
       - /flair-ui
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ .Values.scot4.frontend.traefikMiddlewareVersion }}
 kind: Middleware
 metadata:
   name: http-redirect
@@ -54,6 +57,7 @@ spec:
   redirectScheme:
     scheme: https
     permanent: true
+{{- end }}
 {{- if eq .Values.scot4.redirect.enabled "true" }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/scot4/templates/hooks/scot4-api-deployment-hook.yaml
+++ b/scot4/templates/hooks/scot4-api-deployment-hook.yaml
@@ -22,7 +22,7 @@ data:
   API_EXTERNAL_BASE: {{ .Values.scot4.api.externalApiUri }}
   REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
   ENV: {{ .Values.scot4.api.deploymentEnvironment }}
----  
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -56,6 +56,8 @@ spec:
             name: scot4-env-secrets
       {{- end }}
       restartPolicy: Never
+      {{- if .Values.scot4.common.imagePullSecret }}
       imagePullSecrets:
-      - name: scot4-image-pull-secret
+      - name: {{ .Values.scot4.common.imagePullSecret }}
+      {{- end }}
 {{- end }}

--- a/scot4/templates/inbox/scot4-inbox-alerts.yaml
+++ b/scot4/templates/inbox/scot4-inbox-alerts.yaml
@@ -52,8 +52,10 @@ spec:
             volumeMounts:
             - name: scot4-inbox-alerts-data-storage
               mountPath: /opt/scot4-inbox/var
+          {{- if .Values.scot4.common.imagePullSecret }}
           imagePullSecrets:
-          - name: scot4-image-pull-secret
+          - name: {{ .Values.scot4.common.imagePullSecret }}
+          {{- end }}
           volumes:
           - name: scot4-inbox-alerts-data-storage
             persistentVolumeClaim:
@@ -93,4 +95,4 @@ data:
   S4INBOX_MSV_DBM_FILE: "{{ .Values.scot4.inbox.common.msvDbmFile }}"
   S4INBOX_SCOT_INPUT_QUEUE: "{{ .Values.scot4.inbox.alertgroup.inputQueue }}"
   S4INBOX_MAIL_CLIENT_CLASS: "{{ .Values.scot4.inbox.alertgroup.clientClass }}"
-{{- end }}  
+{{- end }}

--- a/scot4/templates/inbox/scot4-inbox-dispatch.yaml
+++ b/scot4/templates/inbox/scot4-inbox-dispatch.yaml
@@ -52,8 +52,10 @@ spec:
             volumeMounts:
             - name: scot4-inbox-dispatch-data-storage
               mountPath: /opt/scot4-inbox/var
+          {{- if .Values.scot4.common.imagePullSecret }}
           imagePullSecrets:
-          - name: scot4-image-pull-secret
+          - name: {{ .Values.scot4.common.imagePullSecret }}
+          {{- end }}
           volumes:
           - name: scot4-inbox-dispatch-data-storage
             persistentVolumeClaim:

--- a/scot4/templates/inbox/scot4-inbox-events.yaml
+++ b/scot4/templates/inbox/scot4-inbox-events.yaml
@@ -52,8 +52,10 @@ spec:
             volumeMounts:
             - name: scot4-inbox-events-data-storage
               mountPath: /opt/scot4-inbox/var
+          {{- if .Values.scot4.common.imagePullSecret }}
           imagePullSecrets:
-          - name: scot4-image-pull-secret
+          - name: {{ .Values.scot4.common.imagePullSecret }}
+          {{- end }}
           volumes:
           - name: scot4-inbox-events-data-storage
             persistentVolumeClaim:
@@ -94,4 +96,3 @@ data:
   S4INBOX_SCOT_INPUT_QUEUE: "{{ .Values.scot4.inbox.event.inputQueue }}"
   S4INBOX_MAIL_CLIENT_CLASS: "{{ .Values.scot4.inbox.event.clientClass }}"
  {{- end }}
-  

--- a/scot4/templates/search-init/scot4-search-init-job.yaml
+++ b/scot4/templates/search-init/scot4-search-init-job.yaml
@@ -16,5 +16,7 @@ spec:
         - secretRef:
             name: scot4-env-secrets
       restartPolicy: Never
+      {{- if .Values.scot4.common.imagePullSecret }}
       imagePullSecrets:
-      - name: scot4-image-pull-secret 
+      - name: {{ .Values.scot4.common.imagePullSecret }}
+      {{- end }}

--- a/scot4/templates/support/scot4-s3-backup.yaml
+++ b/scot4/templates/support/scot4-s3-backup.yaml
@@ -20,7 +20,7 @@ metadata:
   name: scot4-s3-backup
 spec:
   {{- if eq .Values.scot4.s3.testMode "true" }}
-  schedule: "*/5 * * * *" 
+  schedule: "*/5 * * * *"
   {{- else if eq .Values.scot4.s3.testMode "false" }}
   schedule: "0 0 * * *"
   {{- end }}
@@ -54,11 +54,13 @@ spec:
             volumeMounts:
             - name: scot4-inbox-s3-backup-data-storage
               mountPath: /mnt/backup
+          {{- if .Values.scot4.common.imagePullSecret }}
           imagePullSecrets:
-          - name: scot4-image-pull-secret
+          - name: {{ .Values.scot4.common.imagePullSecret }}
+          {{- end }}
           volumes:
           - name: scot4-inbox-s3-backup-data-storage
             persistentVolumeClaim:
               claimName: scot4-s3-backup-data-pv-claim
           restartPolicy: Never
-{{- end }}  
+{{- end }}

--- a/scot4/values.yaml
+++ b/scot4/values.yaml
@@ -12,7 +12,7 @@ meilisearch:
   envFrom:
     - secretRef:
         name: scot4-env-secrets
-  auth: 
+  auth:
     existingMasterKeySecret: "scot4-env-secrets"
   persistence:
     enabled: true
@@ -26,6 +26,10 @@ meilisearch:
 scot4:
   common:
     noProxy: "localhost,scot4-api-service,scot4-search,scot4-flair-service"
+
+    # If authentication is needed for the repo's, configure it here
+    # To disable, set this to be an empty string
+    imagePullSecret: scot4-image-pull-secret
 
   # needs to be "true" for first install. after first install will clean and rebuild flair's DBs
   clean_flair_install: "false"
@@ -65,9 +69,9 @@ scot4:
     # first superuser's username
     firstSuperUserName: "scot-admin"
     # url to reach flair at, shouldn't need to change
-    flairHost: 'http://scot4-flair-service:3001'
+    flairHost: "http://scot4-flair-service:3001"
     # path to reach flair at, shouldn't need to change
-    flairHostEndpoint: '/api/v1/flair'
+    flairHostEndpoint: "/api/v1/flair"
     # placeholder path for enrichment logic, refer to api code
     enrichmentApiJobEndpoint: "/api/v1/dags/scot4_entity_[ENTITY_TYPE_PLACEHOLDER]_enrichment/dagRuns"
     # enrichment host, likely a deployed airflow instance
@@ -126,8 +130,8 @@ scot4:
     mojo_listen: "http://0.0.0.0:3001?reuse=1"
     mojo_workers: 5
     default_exp_time: 28800
-    admin_user: 'flairadmin'
-    admin_gecos: 'Flair Admin Entity'
+    admin_user: "flairadmin"
+    admin_gecos: "Flair Admin Entity"
     home_dir: "/opt/flair"
     flair_user: "flair"
     flair_group: "flair"
@@ -165,8 +169,8 @@ scot4:
       imapUsername: "username"
       imapPeek: 0
       inputQueue: "alertgroup"
-      clientClass: 'Scot::Inbox::Imap'
-      permittedSenders: '*'
+      clientClass: "Scot::Inbox::Imap"
+      permittedSenders: "*"
 
     dispatch:
       enabled: "false"
@@ -178,8 +182,8 @@ scot4:
       imapUsername: "username"
       imapPeek: 0
       inputQueue: "dispatch"
-      clientClass: 'Scot::Inbox::Imap'
-      permittedSenders: '*'
+      clientClass: "Scot::Inbox::Imap"
+      permittedSenders: "*"
 
     event:
       enabled: "false"
@@ -191,8 +195,8 @@ scot4:
       imapUsername: "username"
       imapPeek: 0
       inputQueue: "event"
-      clientClass: 'Scot::Inbox::Imap'
-      permittedSenders: '*'
+      clientClass: "Scot::Inbox::Imap"
+      permittedSenders: "*"
 
   s3:
     backup_enabled: "false"

--- a/scot4/values.yaml
+++ b/scot4/values.yaml
@@ -108,6 +108,12 @@ scot4:
     tlsSecretName: "scot4-tls"
     # image pull policy for k8s
     imagePullPolicy: "Always"
+    # enable traefik middleware
+    enableTraefikMiddleware: "true"
+    # traefik middleware api version
+    # requires above (`enableTraefikMiddleware`) to be enabled
+    # traefik.containo.us/v1alpha1 or traefik.io/v1alpha1
+    traefikMiddlewareVersion: traefik.containo.us/v1alpha1
 
   flair:
     # flair container image repository path


### PR DESCRIPTION
(This is PR #4 - just correctly branched)

This PR adds two changes:

* Adds a new value `scot4.common.imagePullSecrets`. This accepts a kubernetes secret, to be used when pulling images. To preserve backward compatibility, the previous value has been set here. If you set this value to empty, then `imagePullSecrets` is removed from all deployments.
* Adds a new value `scot4.frontend.enableTraefikMiddleware` (default: true, for BC) and `scot4.frontend.traefikMiddlewareVersion` (default: `traefik.containo.us/v1alpha1` as the previous/BC version). Setting `enableTraefikMiddleware` to false will disable middleware all together. In addition, you can override the middlewareVersion to the newer traefik CRD `traefik.io/v1alpha1` if needed. I'll leave this up to ya'll if you just want to take the latest version.

## Testing
Locally, via:
```
$ helm template scot4 ./scot4 --set scot4.common.imagePullSecret=""
$ helm template scot4 ./scot4 --set scot4.common.imagePullSecret="foobar"
$ helm template scot4 ./scot4 --set scot4.frontend.enableTraefikMiddleware="no"
$ helm template scot4 ./scot4 --set scot4.frontend.enableTraefikMiddleware="traefik.io/v1alpha1"
```